### PR TITLE
[FIX]컴포넌트 분리

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 const basicAxios = axios.create({
   baseURL: process.env.REACT_APP_API_URL,
   headers: {
-    Authorization: `Token ${process.env.REACT_APP_GITHUB_KEY}`,
+    // Authorization: `Token ${process.env.REACT_APP_GITHUB_KEY}`,
     'Content-type': 'application/json',
   },
 })

--- a/src/pages/home/Issue.jsx
+++ b/src/pages/home/Issue.jsx
@@ -1,11 +1,19 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import styled from 'styled-components'
 import IssueList from './components/IssueList'
+import IssueListLoading from './components/IssueListLoading'
+import IssueListError from './components/IssueListError'
+import IssueListLastPageMessage from './components/IssueListLastPageMessage'
 
 const Issue = () => {
+  const currentPage = useRef(1)
+
   return (
     <IssueContainer>
-      <IssueList />
+      <IssueList currentPage={currentPage} />
+      <IssueListLoading />
+      <IssueListError />
+      <IssueListLastPageMessage />
     </IssueContainer>
   )
 }

--- a/src/pages/home/components/IssueList.jsx
+++ b/src/pages/home/components/IssueList.jsx
@@ -2,18 +2,18 @@ import React, { useContext, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import IssueItem from './IssueItem'
 import { GithubContext } from 'context/GithubContext'
-import Loading from 'components/Loading'
 
-const IssueList = () => {
-  const { issueLists, isLoading, getLists, isError, currentPage } = useContext(GithubContext)
+const IssueList = ({ currentPage }) => {
+  const { issueLists, isLoading, getLists, isLastPage, isError } = useContext(GithubContext)
   const observerTarget = useRef(null)
 
   useEffect(() => {
-    if (currentPage.current === 'lastPage' || isError) return
+    if (isLastPage || isError) return
     const bottomWindow = new IntersectionObserver(
       entries => {
         if (entries[0].isIntersecting) {
-          getLists()
+          getLists(currentPage.current)
+          currentPage.current++
         }
       },
       { threshold: 0.7 },
@@ -35,9 +35,7 @@ const IssueList = () => {
           />
         </IssueItemContainer>
       ))}
-      {isLoading ? <Loading /> : <InfinityScrollDiv ref={observerTarget} />}
-      {isError && <ErrorMessage>{isError}</ErrorMessage>}
-      {currentPage.current === 'lastPage' && <LastPageMessage>마지막 페이지입니다</LastPageMessage>}
+      {!isLoading && <InfinityScrollDiv ref={observerTarget} />}
     </>
   )
 }
@@ -50,22 +48,3 @@ const InfinityScrollDiv = styled.div`
 `
 
 const IssueItemContainer = styled.div``
-
-const ErrorMessage = styled.div`
-  position: fixed;
-  ${({ theme }) => theme.flex()};
-  top: 100px;
-  left: 50%;
-  width: max-content;
-  padding: 20px;
-  ${({ theme }) => theme.headerFont}
-  background-color: red;
-  color: white;
-  transform: translateX(-50%);
-`
-
-const LastPageMessage = styled.div`
-  ${({ theme }) => theme.flex()}
-  ${({ theme }) => theme.headerFont}
-  padding-bottom: 30px;
-`

--- a/src/pages/home/components/IssueListError.jsx
+++ b/src/pages/home/components/IssueListError.jsx
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react'
+import styled from 'styled-components'
+import { GithubContext } from 'context/GithubContext'
+
+const IssueListError = () => {
+  const { isError } = useContext(GithubContext)
+
+  return isError && <ErrorMessage>{isError}</ErrorMessage>
+}
+
+export default IssueListError
+
+const ErrorMessage = styled.div`
+  position: fixed;
+  ${({ theme }) => theme.flex()};
+  top: 100px;
+  left: 50%;
+  width: max-content;
+  padding: 20px;
+  ${({ theme }) => theme.headerFont}
+  background-color: red;
+  color: white;
+  transform: translateX(-50%);
+`

--- a/src/pages/home/components/IssueListLastPageMessage.jsx
+++ b/src/pages/home/components/IssueListLastPageMessage.jsx
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react'
+import styled from 'styled-components'
+import { GithubContext } from 'context/GithubContext'
+
+const IssueListLastPageMessage = () => {
+  const { isLastPage } = useContext(GithubContext)
+
+  return isLastPage && <LastPageMessage>마지막 페이지입니다</LastPageMessage>
+}
+
+export default IssueListLastPageMessage
+
+const LastPageMessage = styled.div`
+  ${({ theme }) => theme.flex()}
+  ${({ theme }) => theme.headerFont}
+  padding-bottom: 30px;
+`

--- a/src/pages/home/components/IssueListLoading.jsx
+++ b/src/pages/home/components/IssueListLoading.jsx
@@ -1,0 +1,11 @@
+import React, { useContext } from 'react'
+import { GithubContext } from 'context/GithubContext'
+import Loading from 'components/Loading'
+
+const IssueListLoading = () => {
+  const { isLoading } = useContext(GithubContext)
+
+  return isLoading && <Loading />
+}
+
+export default IssueListLoading


### PR DESCRIPTION
로딩중,에러메세지,마지막페이지를 표현하는 컴포넌트를 분리하였습니다

context 에서는 받아오는 데이터를 관리하고, getLists 함수를 통해서 추가 데이터를 불러올 수 있도록 하였습니다.

context에서 로딩,에러, 마지막페이지를 판별하도록 하였습니다, 불러오는 데이터의 길이가 0일때 마지막페이지를 나타내도록 하였고,

각각의 state 값을 해당 컴포넌트로 넘겨주며 각각의 state 값에따라 로딩중 또는 에러메세지 또는 마지막 페이지를 나타내도록 하였습니다.

intersection observer 의 경우, 에러메세지 또는 로딩중에는 해당 element가 나타나지 않도록 하여 불필요한 api 호출이 발생하지 않도록

진행 하였습니다.